### PR TITLE
Restrict matplotlib

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,4 @@ dependencies:
     - python>=3.8
     - pygimli=1.2.5
     - jupyterlab
+    - matplotlib<3.5


### PR DESCRIPTION
`matplotlib>=3.5` with `pygimli=1.2.5` results in a `TypeError: int() argument must be a string, a bytes-like object or a number, not 'slice'` for some plotting commands. Restricting therefore matplotlib.